### PR TITLE
Fix teleports

### DIFF
--- a/src/entities/player.rs
+++ b/src/entities/player.rs
@@ -2,6 +2,7 @@ use crate::constantes;
 use crate::entities::{
     foilage::Grass,
     skeleton::{Skeleton, SkeletonBlock},
+    ai::AiState
 };
 use crate::particle_system;
 use crate::particle_system::ParticleSystemCollection;
@@ -242,7 +243,9 @@ pub fn system(
                     .get_mut(other_teleporter_index)
                     .unwrap();
                 if let Some(other_teleporter) = other_teleporter_option {
+                    // Force visual insta jump
                     player.transform.position = other_teleporter.transform.position;
+                    player.sprite.visual_position = other_teleporter.sprite.visual_position;
                     sound_collection.play(3);
                     player.sprite.blink_timer = constantes::TIME_BLINK;
                     other_teleporter.sprite.blink_timer = constantes::TIME_BLINK;

--- a/src/entities/player.rs
+++ b/src/entities/player.rs
@@ -249,6 +249,14 @@ pub fn system(
                     sound_collection.play(3);
                     player.sprite.blink_timer = constantes::TIME_BLINK;
                     other_teleporter.sprite.blink_timer = constantes::TIME_BLINK;
+
+                    let skeleton_option = game_state
+                        .skeletons
+                        .iter_mut()
+                        .find(|s| s.transform.position == other_teleporter.transform.position);
+                    if let Some(skeleton) = skeleton_option {
+                        skeleton.ai.state = AiState::Attack;
+                    }
                 }
             }
             // Exit

--- a/src/entities/skeleton.rs
+++ b/src/entities/skeleton.rs
@@ -244,10 +244,11 @@ pub fn attack(
 
                 let blood_particles = particle_collection.get_mut(*blood_id).unwrap();
                 blood_particles.scale = screen_size.x / 16.0;
-                let pos_player_visual = player.sprite.visual_position;
+                // Use the skeleton position to handle teleports
+                let pos_skeleton_visual = skeleton.sprite.visual_position;
                 let mut pos_particle = na::Vector2::new(
-                    pos_player_visual.x / screen_size.x * 16.0,
-                    pos_player_visual.y / screen_size.x * 16.0,
+                    pos_skeleton_visual.x / screen_size.x * 16.0,
+                    pos_skeleton_visual.y / screen_size.x * 16.0,
                 );
                 pos_particle += na::Vector2::new(16.0 * 0.5, 16.0 * 0.5);
 


### PR DESCRIPTION
Teleporting to a door with a skeleton in front does now kill you and to fix animations, teleports are now instant.